### PR TITLE
changed height_increment to float instead of int

### DIFF
--- a/post_processing_scripts/VaryTempWithHeight.py
+++ b/post_processing_scripts/VaryTempWithHeight.py
@@ -32,7 +32,7 @@ class VaryTempWithHeight(Script):
                         "changes by this much"
                     ),
                     "unit": "mm",
-                    "type": "int",
+                    "type": "float",
                     "default_value": 10,
                 },
                 "temperature_decrement": {


### PR DESCRIPTION
I printed a calibration tower with different heights, and I needed this value to be a float so that I could adjust offsets accordingly.